### PR TITLE
解决无法推送到pypi的问题

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='jdcloud_sdk',
     version="1.5.10",
-    description=long_description,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author='JDCloud API Gateway Team',
     url='https://github.com/jdcloud-api/jdcloud-sdk-python',
     scripts=[],


### PR DESCRIPTION
HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/